### PR TITLE
Show temperature in Fahrenheit

### DIFF
--- a/temperature_gui.py
+++ b/temperature_gui.py
@@ -205,10 +205,11 @@ class TemperatureGUI:
         self._after_id = self.root.after(self.DT_MS, self._update)
 
     def _update(self) -> None:
-        temp, rate = self._scope.read()
-        self.temp_str.set(f"Temperature: {temp:.0f} °C")
+        temp_c, rate = self._scope.read()
+        temp_f = temp_c * 9.0 / 5.0 + 32.0
+        self.temp_str.set(f"Temperature: {temp_f:.0f} °F")
         self.rate_str.set(f"Sample rate: {RATE_LABELS.get(rate, rate)}")
-        self._draw_thermometer(temp)
+        self._draw_thermometer(temp_c)
         if self.connected:
             self._schedule_update()
 


### PR DESCRIPTION
## Summary
- Display temperature in Fahrenheit rather than Celsius in the GUI.

## Testing
- `python3 -m py_compile temperature_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19a94d1288323927d149e2a97027e